### PR TITLE
Remove deprecated execCommand in clipboard-copy

### DIFF
--- a/src/SprykerShop/Yves/ShopUi/Theme/default/components/molecules/clipboard-copy/clipboard-copy.ts
+++ b/src/SprykerShop/Yves/ShopUi/Theme/default/components/molecules/clipboard-copy/clipboard-copy.ts
@@ -53,10 +53,10 @@ export default class ClipboardCopy extends Component {
             return;
         }
 
-        this.target.select();
-        document.execCommand('copy');
-        this.showMessage(this.successCopyMessage, this.defaultDuration);
-        this.dispatchCustomEvent(EVENT_COPY);
+        navigator.clipboard.writeText(this.target.value).then(() => {
+            this.showMessage(this.successCopyMessage, this.defaultDuration);
+            this.dispatchCustomEvent(EVENT_COPY);
+        });
     }
 
     /**
@@ -106,7 +106,7 @@ export default class ClipboardCopy extends Component {
      * Gets if a browser supports the automatically copy to clipboard feature.
      */
     get isCopyCommandSupported(): boolean {
-        return document.queryCommandSupported('copy');
+        return navigator.clipboard && window.isSecureContext;
     }
 
     /**


### PR DESCRIPTION
> ### Document.execCommand()
> Deprecated: This feature is no longer recommended. Though some browsers might still support it, it may have already been removed from the relevant web standards, may be in the process of being dropped, or may only be kept for compatibility purposes. Avoid using it, and update existing code if possible; see the [compatibility table](https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand#browser_compatibility) at the bottom of this page to guide your decision. Be aware that this feature may cease to work at any time.

Source: https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand