### PR TITLE
Fixathon: Add image alt text

### DIFF
--- a/contribution-license-agreement.txt
+++ b/contribution-license-agreement.txt
@@ -1,0 +1,1 @@
+I hereby agree to Spryker's Contribution License Agreement in https://github.com/spryker-shop/shop-ui/blob/345106e734759757f87b9c2e81c16ab047421df5/CONTRIBUTING.md

--- a/src/SprykerShop/Yves/ShopUi/Theme/default/components/molecules/product-item/product-item.twig
+++ b/src/SprykerShop/Yves/ShopUi/Theme/default/components/molecules/product-item/product-item.twig
@@ -11,7 +11,7 @@
     sku: data.product.sku | default,
     url: data.product.url | default,
     image: data.product.images is defined ? data.product.images.0.externalUrlSmall | default,
-    imageAlt: data.product.images is defined and data.product.images.0.altText is defined ? data.product.images.0.altText : data.name | default,
+    imageAlt: data.product.images is defined and data.product.images.0.altTextSmall is defined ? data.product.images.0.altTextSmall : data.name | default,
     idProductAbstract: data.product.idProductAbstract | default,
     currencyIsoCode: null,
     metaSku: data.product.sku is defined ? data.product.sku : (data.product.abstract_sku is defined ? data.product.abstract_sku : ''),

--- a/src/SprykerShop/Yves/ShopUi/Theme/default/components/molecules/product-item/product-item.twig
+++ b/src/SprykerShop/Yves/ShopUi/Theme/default/components/molecules/product-item/product-item.twig
@@ -11,7 +11,7 @@
     sku: data.product.sku | default,
     url: data.product.url | default,
     image: data.product.images is defined ? data.product.images.0.externalUrlSmall | default,
-    imageAlt: data.product.images is defined and data.product.images.0.altTextSmall is defined ? data.product.images.0.altTextSmall : data.name | default,
+    imageAlt: data.product.images is defined and data.product.images.0.alt_text_small is defined ? data.product.images.0.alt_text_small : data.name | default,
     idProductAbstract: data.product.idProductAbstract | default,
     currencyIsoCode: null,
     metaSku: data.product.sku is defined ? data.product.sku : (data.product.abstract_sku is defined ? data.product.abstract_sku : ''),


### PR DESCRIPTION
## PR Description
This PR and all included in Core PRs enable Spryker users to set HTML alt text for product images in small and large version.

## Steps before you submit a PR
- Please add tests for the code you add if it's possible.
- Please check out our contribution guide: https://docs.spryker.com/docs/dg/dev/code-contribution-guide.html
- Add a `contribution-license-agreement.txt` file with the following content:
`I hereby agree to Spryker\'s Contribution License Agreement in https://github.com/spryker-shop/shop-ui/blob/HASH_OF_COMMIT_YOU_ARE_BASING_YOUR_BRANCH_FROM_MASTER_BRANCH/CONTRIBUTING.md.`

This is a mandatory step to make sure you are aware of the license agreement and agree to it. `HASH_OF_COMMIT_YOU_ARE_BASING_YOUR_BRANCH_FROM_MASTER_BRANCH` is a hash of the commit you are basing your branch from the master branch. You can take it from commits list of master branch before you submit a PR.

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
